### PR TITLE
security settings of favonia/cloudflare-ddns

### DIFF
--- a/k3s/k3s-trusted/workloads/cloudflare-ddns/deployment.yml
+++ b/k3s/k3s-trusted/workloads/cloudflare-ddns/deployment.yml
@@ -23,17 +23,12 @@ spec:
           imagePullPolicy: Always
           securityContext:
             capabilities:
-              add: ["SETUID", "SETGID"]
               drop: ["ALL"]
             readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 1000
             allowPrivilegeEscalation: false
           env:
-            - name: PUID
-              value: "1000"
-            - name: PGID
-              value: "1000"
             - name: CF_API_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.